### PR TITLE
Fix some bugs

### DIFF
--- a/src/main/kotlin/io/github/crackthecodeabhi/kreds/commands/JsonCommands.kt
+++ b/src/main/kotlin/io/github/crackthecodeabhi/kreds/commands/JsonCommands.kt
@@ -264,7 +264,7 @@ public interface JsonCommands {
         value: String,
         start: Int = 0,
         stop: Int = 0
-    ): List<Int?>
+    ): List<Long?>
 
     /**
      * ### ` JSON.ARRINSERT key path index value [value ...] `
@@ -564,7 +564,7 @@ internal interface JsonCommandExecutor : BaseJsonCommands, JsonCommands, Command
     ): List<Int?> =
         execute(_jsonArrAppend(key, path, arrayOf(element, *elements))).responseTo()
 
-    override suspend fun jsonArrIndex(key: String, path: String, value: String, start: Int, stop: Int): List<Int?> =
+    override suspend fun jsonArrIndex(key: String, path: String, value: String, start: Int, stop: Int): List<Long?> =
         execute(_jsonArrIndex(key, path, value, start, stop)).responseTo()
 
     override suspend fun jsonArrInsert(key: String, path: String, index: Int, elements: Array<String>): List<Int?> =
@@ -608,7 +608,7 @@ internal interface JsonCommandExecutor : BaseJsonCommands, JsonCommands, Command
         indent: String?,
         newline: String?,
         space: String?
-    ): String? = execute(_jsonGet(key, paths = arrayOf(path, *paths), indent, newline, space)).responseTo()
+    ): String? = execute(_jsonGet(key, paths = arrayOf(path, *paths), indent, newline, space))
 
     override suspend fun jsonMGet(keys: Array<String>, path: String): List<String> =
         execute(_jsonMGet(keys, path)).responseTo()

--- a/src/main/kotlin/io/github/crackthecodeabhi/kreds/commands/StringCommands.kt
+++ b/src/main/kotlin/io/github/crackthecodeabhi/kreds/commands/StringCommands.kt
@@ -59,10 +59,10 @@ internal interface BaseStringCommands {
     fun _set(key: String, value: String, setOption: SetOption?) =
         CommandExecution(SET, SimpleAndBulkStringCommandProcessor, *createArguments(
             key, value,
-            setOption?.exSeconds?.let { KeyValueArgument("EX", it.toString(10)) },
-            setOption?.pxMilliseconds?.let { KeyValueArgument("PX", it.toString(10)) },
-            setOption?.exatTimestamp?.let { KeyValueArgument("EXAT", it.toString(10)) },
-            setOption?.pxatMillisecondTimestamp?.let { KeyValueArgument("PXAT", it.toString(10)) },
+            setOption?.exSeconds?.let { Pair("EX", it.toString(10)) },
+            setOption?.pxMilliseconds?.let { Pair("PX", it.toString(10)) },
+            setOption?.exatTimestamp?.let { Pair("EXAT", it.toString(10)) },
+            setOption?.pxatMillisecondTimestamp?.let { Pair("PXAT", it.toString(10)) },
             setOption?.keepTTL?.let { KeyOnlyArgument("KEEPTTL") },
             setOption?.nx?.let { KeyOnlyArgument("NX") },
             setOption?.xx?.let { KeyOnlyArgument("XX") },
@@ -72,10 +72,10 @@ internal interface BaseStringCommands {
     fun _getEx(key: String, getExOption: GetExOption? = null) =
         CommandExecution(GETEX, BulkStringCommandProcessor, *createArguments(
             key,
-            getExOption?.exSeconds?.let { KeyValueArgument("EX", it.toString(10)) },
-            getExOption?.pxMilliseconds?.let { KeyValueArgument("PX", it.toString(10)) },
-            getExOption?.exatTimestamp?.let { KeyValueArgument("EXAT", it.toString(10)) },
-            getExOption?.pxatMillisecondTimestamp?.let { KeyValueArgument("PXAT", it.toString(10)) },
+            getExOption?.exSeconds?.let { Pair("EX", it.toString(10)) },
+            getExOption?.pxMilliseconds?.let { Pair("PX", it.toString(10)) },
+            getExOption?.exatTimestamp?.let { Pair("EXAT", it.toString(10)) },
+            getExOption?.pxatMillisecondTimestamp?.let { Pair("PXAT", it.toString(10)) },
             getExOption?.persist?.let { KeyOnlyArgument("PERSIST") }
         ))
 


### PR DESCRIPTION
I found some bugs while using Kreds in my own projects:
- Using `JSON.ARRINDEX` could throw casting exceptions because I accidentally made the return value `List<Int?>` instead of `List<Long?>`
- Using `JSON.ARRINDEX` would throw an exception when the return value is null because of `.responseTo()` (also my fault)
- Using `SetOption` and `GetExOption` also was throwing some exceptions. Changing `KeyValueArgument` to `Pair` seems to have fixed it

This PR should fix them