### PR TITLE
Fix: ZRANGE scores parameter bug

### DIFF
--- a/src/main/kotlin/io/github/crackthecodeabhi/kreds/commands/ZSetCommands.kt
+++ b/src/main/kotlin/io/github/crackthecodeabhi/kreds/commands/ZSetCommands.kt
@@ -267,9 +267,19 @@ internal interface BaseZSetCommands {
             min,
             max,
             by,
-            rev?.let { KeyOnlyArgument("REV") },
+            rev?.let {
+                if (it)
+                    KeyOnlyArgument("REV")
+                else
+                    EmptyArgument
+            },
             limit?.let { KeyValueArgument("LIMIT","${it.first} ${it.second}") },
-            withScores.let { "WITHSCORES" }
+            withScores?.let {
+                if (it)
+                    KeyOnlyArgument("WITHSCORES")
+                else
+                    EmptyArgument
+            }
         )
     )
 }


### PR DESCRIPTION
Values of withScores and res are now taken into account when creating arguments for ZRANGE command.

This PR fixes issue #64 