### PR TITLE
Functions support

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ All the following redis features are supported:
 * Connection handling commands. :heavy_check_mark:
 * RedisJSON support. :heavy_check_mark:
 * Scripting support. :heavy_check_mark:
+* Functions. :heavy_check_mark:
 * Transactions. :construction: [Implementation done, testing in progress.]
 
 ## How do I use it?

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,14 +24,14 @@ println("Gradle Running on Java: ${JavaVersion.current()}")
 println("============================")
 
 plugins {
-    kotlin("jvm") version "1.6.21"
+    kotlin("jvm") version "1.8.22"
     id("org.jetbrains.dokka") version "1.7.10"
     id("io.github.gradle-nexus.publish-plugin") version "1.1.0"
     `java-library`
     `maven-publish`
     signing
     id("com.dorongold.task-tree") version "2.1.1"
-    id("io.gitlab.arturbosch.detekt") version "1.18.0"
+    id("io.gitlab.arturbosch.detekt") version "1.23.0"
     jacoco
 }
 
@@ -76,6 +76,7 @@ dependencies {
     implementation("io.netty:netty-handler:4.1.91.Final")
     implementation(kotlin("stdlib"))
     api("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4")
+    detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:1.23.0")
 
     testImplementation("io.kotest:kotest-runner-junit5:5.5.4")
     testImplementation("io.kotest:kotest-assertions-core:5.5.4")

--- a/src/main/kotlin/io/github/crackthecodeabhi/kreds/args/api.kt
+++ b/src/main/kotlin/io/github/crackthecodeabhi/kreds/args/api.kt
@@ -198,3 +198,9 @@ public class Weights(public val weight: Int, public val weights: Array<Int>? = n
 public enum class JsonSetOption : Argument {
     NX, XX
 }
+
+public enum class FunctionRestorePolicy : Argument {
+    FLUSH, APPEND, REPLACE;
+
+    override fun toString(): String = name
+}

--- a/src/main/kotlin/io/github/crackthecodeabhi/kreds/commands/FunctionCommands.kt
+++ b/src/main/kotlin/io/github/crackthecodeabhi/kreds/commands/FunctionCommands.kt
@@ -26,14 +26,11 @@ import io.github.crackthecodeabhi.kreds.args.toArgument
 import io.github.crackthecodeabhi.kreds.commands.FunctionCommand.FUNCTION_DELETE
 import io.github.crackthecodeabhi.kreds.commands.FunctionCommand.FUNCTION_FLUSH
 import io.github.crackthecodeabhi.kreds.commands.FunctionCommand.FUNCTION_KILL
-import io.github.crackthecodeabhi.kreds.commands.FunctionCommand.FUNCTION_LIST
 import io.github.crackthecodeabhi.kreds.commands.FunctionSubCommand.DELETE
 import io.github.crackthecodeabhi.kreds.commands.FunctionSubCommand.FLUSH
 import io.github.crackthecodeabhi.kreds.commands.FunctionSubCommand.KILL
-import io.github.crackthecodeabhi.kreds.commands.FunctionSubCommand.LIST
 import io.github.crackthecodeabhi.kreds.commands.FunctionSubCommand.LOAD
 import io.github.crackthecodeabhi.kreds.protocol.AllCommandProcessor
-import io.github.crackthecodeabhi.kreds.protocol.ArrayCommandProcessor
 import io.github.crackthecodeabhi.kreds.protocol.BulkStringCommandProcessor
 import io.github.crackthecodeabhi.kreds.protocol.CommandExecutor
 import io.github.crackthecodeabhi.kreds.protocol.SimpleStringCommandProcessor
@@ -47,12 +44,11 @@ internal enum class FunctionCommand(
     FUNCTION_DELETE(DELETE),
     FUNCTION_FLUSH(FLUSH),
     FUNCTION_KILL(KILL),
-    FUNCTION_LIST(LIST),
     FUNCTION_LOAD(LOAD);
 }
 
 internal enum class FunctionSubCommand(override val subCommand: Command? = null) : Command {
-    DELETE, FLUSH, KILL, LIST, LOAD;
+    DELETE, FLUSH, KILL, LOAD;
 
     override val string = name
 }
@@ -74,13 +70,6 @@ internal interface BaseFunctionCommands {
         CommandExecution(FUNCTION_FLUSH, SimpleStringCommandProcessor, sync)
 
     fun _functionKill() = CommandExecution(FUNCTION_KILL, SimpleStringCommandProcessor)
-
-    fun _functionList(libraryName: String?, withCode: Boolean) = CommandExecution(
-        FUNCTION_LIST,
-        ArrayCommandProcessor,
-        libraryName.toArgument(),
-        if (withCode) "WITHCODE".toArgument() else EmptyArgument
-    )
 
     fun _functionLoad(replace: Boolean, functionCode: String) = CommandExecution(
         FunctionCommand.FUNCTION_LOAD,

--- a/src/main/kotlin/io/github/crackthecodeabhi/kreds/commands/FunctionCommands.kt
+++ b/src/main/kotlin/io/github/crackthecodeabhi/kreds/commands/FunctionCommands.kt
@@ -91,6 +91,15 @@ internal interface BaseFunctionCommands {
 }
 
 public interface FunctionCommands {
+    /**
+     * ### `FCALL function numkeys [key [key ...]] [arg [arg ...]]`
+     * Invokes a function.
+     *
+     * [Doc](https://redis.io/commands/fcall/)
+     * @since 7.0.0
+     * @param readOnly Whether to allow commands that modify data
+     * @return Value returned by executed function
+     */
     public suspend fun fcall(
         function: String,
         keys: Array<String>,
@@ -98,12 +107,41 @@ public interface FunctionCommands {
         readOnly: Boolean = false
     ): Any?
 
-    public suspend fun functionDelete(libraryName: String): String
+    /**
+     * ### `FUNCTION DELETE library-name`
+     * Delete a library and all its functions.
+     *
+     * [Doc](https://redis.io/commands/function-delete/)
+     * @since 7.0.0
+     */
+    public suspend fun functionDelete(libraryName: String)
 
-    public suspend fun functionFlush(sync: SyncOption): String
+    /**
+     * ### `FUNCTION FLUSH [ASYNC | SYNC]`
+     * Deletes all the libraries.
+     *
+     * [Doc](https://redis.io/commands/function-flush/)
+     * @since 7.0.0
+     */
+    public suspend fun functionFlush(sync: SyncOption)
 
-    public suspend fun functionKill(): String
+    /**
+     * ### `FUNCTION KILL`
+     * Kill a function that is currently executing.
+     *
+     * [Doc](https://redis.io/commands/function-kill/)
+     * @since 7.0.0
+     */
+    public suspend fun functionKill()
 
+    /**
+     * ### `FUNCTION LOAD \[REPLACE] function-code`
+     * Loads a library to Redis.
+     *
+     * [Doc](https://redis.io/commands/function-load/)
+     * @since 7.0.0
+     * @return The library name that was loaded
+     */
     public suspend fun functionLoad(replace: Boolean, functionCode: String): String
 }
 
@@ -111,11 +149,17 @@ internal interface FunctionCommandExecutor : CommandExecutor, FunctionCommands, 
     override suspend fun fcall(function: String, keys: Array<String>, args: Array<String>, readOnly: Boolean) =
         execute(_fcall(function, keys, args, readOnly))
 
-    override suspend fun functionDelete(libraryName: String): String = execute(_functionDelete(libraryName))
+    override suspend fun functionDelete(libraryName: String) {
+        execute(_functionDelete(libraryName))
+    }
 
-    override suspend fun functionFlush(sync: SyncOption): String = execute(_functionFlush(sync))
+    override suspend fun functionFlush(sync: SyncOption) {
+        execute(_functionFlush(sync))
+    }
 
-    override suspend fun functionKill(): String = execute(_functionKill())
+    override suspend fun functionKill() {
+        execute(_functionKill())
+    }
 
     override suspend fun functionLoad(replace: Boolean, functionCode: String): String =
         execute(_functionLoad(replace, functionCode)).responseTo()

--- a/src/main/kotlin/io/github/crackthecodeabhi/kreds/commands/FunctionCommands.kt
+++ b/src/main/kotlin/io/github/crackthecodeabhi/kreds/commands/FunctionCommands.kt
@@ -1,0 +1,122 @@
+/*
+ *  Copyright (C) 2023 Abhijith Shivaswamy
+ *   See the notice.md file distributed with this work for additional
+ *   information regarding copyright ownership.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+package io.github.crackthecodeabhi.kreds.commands
+
+import io.github.crackthecodeabhi.kreds.args.EmptyArgument
+import io.github.crackthecodeabhi.kreds.args.SyncOption
+import io.github.crackthecodeabhi.kreds.args.createArguments
+import io.github.crackthecodeabhi.kreds.args.toArgument
+import io.github.crackthecodeabhi.kreds.commands.FunctionCommand.FUNCTION_DELETE
+import io.github.crackthecodeabhi.kreds.commands.FunctionCommand.FUNCTION_FLUSH
+import io.github.crackthecodeabhi.kreds.commands.FunctionCommand.FUNCTION_KILL
+import io.github.crackthecodeabhi.kreds.commands.FunctionCommand.FUNCTION_LIST
+import io.github.crackthecodeabhi.kreds.commands.FunctionSubCommand.DELETE
+import io.github.crackthecodeabhi.kreds.commands.FunctionSubCommand.FLUSH
+import io.github.crackthecodeabhi.kreds.commands.FunctionSubCommand.KILL
+import io.github.crackthecodeabhi.kreds.commands.FunctionSubCommand.LIST
+import io.github.crackthecodeabhi.kreds.commands.FunctionSubCommand.LOAD
+import io.github.crackthecodeabhi.kreds.protocol.AllCommandProcessor
+import io.github.crackthecodeabhi.kreds.protocol.ArrayCommandProcessor
+import io.github.crackthecodeabhi.kreds.protocol.BulkStringCommandProcessor
+import io.github.crackthecodeabhi.kreds.protocol.CommandExecutor
+import io.github.crackthecodeabhi.kreds.protocol.SimpleStringCommandProcessor
+
+internal enum class FunctionCommand(
+    override val subCommand: Command?,
+    override val string: String = "FUNCTION"
+) : Command {
+    FCALL(null, "FCALL"),
+    FCALL_RO(null, "FCALL_RO"),
+    FUNCTION_DELETE(DELETE),
+    FUNCTION_FLUSH(FLUSH),
+    FUNCTION_KILL(KILL),
+    FUNCTION_LIST(LIST),
+    FUNCTION_LOAD(LOAD);
+}
+
+internal enum class FunctionSubCommand(override val subCommand: Command? = null) : Command {
+    DELETE, FLUSH, KILL, LIST, LOAD;
+
+    override val string = name
+}
+
+internal interface BaseFunctionCommands {
+    fun _fcall(function: String, keys: Array<String>, args: Array<String>, readOnly: Boolean) = CommandExecution(
+        if (readOnly) FunctionCommand.FCALL_RO else FunctionCommand.FCALL,
+        AllCommandProcessor,
+        function.toArgument(),
+        keys.size.toArgument(),
+        *createArguments(*keys),
+        *createArguments(*args)
+    )
+
+    fun _functionDelete(libraryName: String) =
+        CommandExecution(FUNCTION_DELETE, SimpleStringCommandProcessor, libraryName.toArgument())
+
+    fun _functionFlush(sync: SyncOption) =
+        CommandExecution(FUNCTION_FLUSH, SimpleStringCommandProcessor, sync)
+
+    fun _functionKill() = CommandExecution(FUNCTION_KILL, SimpleStringCommandProcessor)
+
+    fun _functionList(libraryName: String?, withCode: Boolean) = CommandExecution(
+        FUNCTION_LIST,
+        ArrayCommandProcessor,
+        libraryName.toArgument(),
+        if (withCode) "WITHCODE".toArgument() else EmptyArgument
+    )
+
+    fun _functionLoad(replace: Boolean, functionCode: String) = CommandExecution(
+        FunctionCommand.FUNCTION_LOAD,
+        BulkStringCommandProcessor,
+        if (replace) "REPLACE".toArgument() else EmptyArgument,
+        functionCode.toArgument()
+    )
+}
+
+public interface FunctionCommands {
+    public suspend fun fcall(
+        function: String,
+        keys: Array<String>,
+        args: Array<String>,
+        readOnly: Boolean = false
+    ): Any?
+
+    public suspend fun functionDelete(libraryName: String): String
+
+    public suspend fun functionFlush(sync: SyncOption): String
+
+    public suspend fun functionKill(): String
+
+    public suspend fun functionLoad(replace: Boolean, functionCode: String): String
+}
+
+internal interface FunctionCommandExecutor : CommandExecutor, FunctionCommands, BaseFunctionCommands {
+    override suspend fun fcall(function: String, keys: Array<String>, args: Array<String>, readOnly: Boolean) =
+        execute(_fcall(function, keys, args, readOnly))
+
+    override suspend fun functionDelete(libraryName: String): String = execute(_functionDelete(libraryName))
+
+    override suspend fun functionFlush(sync: SyncOption): String = execute(_functionFlush(sync))
+
+    override suspend fun functionKill(): String = execute(_functionKill())
+
+    override suspend fun functionLoad(replace: Boolean, functionCode: String): String =
+        execute(_functionLoad(replace, functionCode)).responseTo()
+}

--- a/src/main/kotlin/io/github/crackthecodeabhi/kreds/connection/Client.kt
+++ b/src/main/kotlin/io/github/crackthecodeabhi/kreds/connection/Client.kt
@@ -63,7 +63,7 @@ public suspend fun shutdown() {
 
 public interface KredsClient : AutoCloseable, KeyCommands, StringCommands, ConnectionCommands, PublisherCommands,
     HashCommands, SetCommands,
-    ListCommands, HyperLogLogCommands, ServerCommands, ZSetCommands, JsonCommands, ScriptingCommands {
+    ListCommands, HyperLogLogCommands, ServerCommands, ZSetCommands, JsonCommands, ScriptingCommands, FunctionCommands {
     public fun pipelined(): Pipeline
     public fun transaction(): Transaction
 }
@@ -119,7 +119,7 @@ internal class DefaultKredsClient(
     AbstractKredsClient(endpoint, eventLoopGroup, config), KredsClient, InternalKredsClient, KeyCommandExecutor,
     StringCommandsExecutor, ConnectionCommandsExecutor, PublishCommandExecutor, HashCommandsExecutor,
     SetCommandExecutor, ListCommandExecutor, HyperLogLogCommandExecutor, ServerCommandExecutor, BlockingKredsClient,
-    ZSetCommandExecutor, JsonCommandExecutor, ScriptingCommandExecutor {
+    ZSetCommandExecutor, JsonCommandExecutor, ScriptingCommandExecutor, FunctionCommandExecutor {
 
     override val mutex: Mutex = Mutex()
 

--- a/src/test/kotlin/io/github/crackthecodeabhi/kreds/commands/FunctionCommandsTest.kt
+++ b/src/test/kotlin/io/github/crackthecodeabhi/kreds/commands/FunctionCommandsTest.kt
@@ -72,12 +72,12 @@ class FunctionCommandsTest : FunSpec({
             client.fcall("test_function", arrayOf("key"), arrayOf("value"), readOnly = true)
         }
 
-        client.functionDelete(moduleName).shouldBeOk()
+        client.functionDelete(moduleName)
         checkNotFound()
 
         client.functionLoad(replace = false, code) shouldBe moduleName
 
-        client.functionFlush(SyncOption.SYNC).shouldBeOk()
+        client.functionFlush(SyncOption.SYNC)
         checkNotFound()
 
         shouldThrow<KredsRedisDataException> {

--- a/src/test/kotlin/io/github/crackthecodeabhi/kreds/commands/FunctionCommandsTest.kt
+++ b/src/test/kotlin/io/github/crackthecodeabhi/kreds/commands/FunctionCommandsTest.kt
@@ -1,0 +1,88 @@
+/*
+ *  Copyright (C) 2023 Abhijith Shivaswamy
+ *   See the notice.md file distributed with this work for additional
+ *   information regarding copyright ownership.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+package io.github.crackthecodeabhi.kreds.commands
+
+import io.github.crackthecodeabhi.kreds.args.SyncOption
+import io.github.crackthecodeabhi.kreds.connection.KredsClient
+import io.github.crackthecodeabhi.kreds.protocol.KredsRedisDataException
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class FunctionCommandsTest : FunSpec({
+    lateinit var client: KredsClient
+    val clientSetup = ClientSetup().then { client = it.client }
+    beforeSpec(clientSetup)
+    afterSpec(ClientTearDown(clientSetup))
+    beforeTest(ClearDB(clientSetup))
+    beforeTest { client.functionFlush(SyncOption.SYNC) }
+
+    test("Function commands").config(enabledOrReasonIf = clientSetup.enableIf(REDIS_7_0_0)) {
+        suspend fun checkNotFound() {
+            shouldThrow<KredsRedisDataException> {
+                // ERR Function not found
+                client.fcall("test_function", arrayOf("key"), arrayOf("value"))
+            }
+        }
+
+        checkNotFound()
+
+        val moduleName = "functionstest"
+        val code = """
+            #!lua name=$moduleName
+            redis.register_function("test_function", function(keys, args)
+                return redis.call("SET", keys[1], args[1])
+            end)
+        """.trimIndent()
+
+        client.functionLoad(replace = false, code) shouldBe moduleName
+
+        shouldThrow<KredsRedisDataException> {
+            // ERR Library 'functionstest' already exists
+            client.functionLoad(replace = false, code)
+        }
+
+        client.functionLoad(replace = true, code) shouldBe moduleName
+
+        val key = "test_key"
+        val value = "Hello World"
+        (client.fcall("test_function", arrayOf(key), arrayOf(value)) as String).shouldBeOk()
+        client.get(key) shouldBe value
+        client.del(key)
+
+        shouldThrow<KredsRedisDataException> {
+            // ERR Can not execute a script with write flag using *_ro command.
+            client.fcall("test_function", arrayOf("key"), arrayOf("value"), readOnly = true)
+        }
+
+        client.functionDelete(moduleName).shouldBeOk()
+        checkNotFound()
+
+        client.functionLoad(replace = false, code) shouldBe moduleName
+
+        client.functionFlush(SyncOption.SYNC).shouldBeOk()
+        checkNotFound()
+
+        shouldThrow<KredsRedisDataException> {
+            // NOTBUSY No scripts in execution right now.
+            client.functionKill()
+        }
+    }
+})

--- a/src/test/kotlin/io/github/crackthecodeabhi/kreds/commands/FunctionCommandsTest.kt
+++ b/src/test/kotlin/io/github/crackthecodeabhi/kreds/commands/FunctionCommandsTest.kt
@@ -44,22 +44,22 @@ class FunctionCommandsTest : FunSpec({
 
         checkNotFound()
 
-        val moduleName = "functionstest"
+        val libraryName = "functionstest"
         val code = """
-            #!lua name=$moduleName
+            #!lua name=$libraryName
             redis.register_function("test_function", function(keys, args)
                 return redis.call("SET", keys[1], args[1])
             end)
         """.trimIndent()
 
-        client.functionLoad(replace = false, code) shouldBe moduleName
+        client.functionLoad(replace = false, code) shouldBe libraryName
 
         shouldThrow<KredsRedisDataException> {
             // ERR Library 'functionstest' already exists
             client.functionLoad(replace = false, code)
         }
 
-        client.functionLoad(replace = true, code) shouldBe moduleName
+        client.functionLoad(replace = true, code) shouldBe libraryName
 
         val key = "test_key"
         val value = "Hello World"
@@ -72,10 +72,10 @@ class FunctionCommandsTest : FunSpec({
             client.fcall("test_function", arrayOf("key"), arrayOf("value"), readOnly = true)
         }
 
-        client.functionDelete(moduleName)
+        client.functionDelete(libraryName)
         checkNotFound()
 
-        client.functionLoad(replace = false, code) shouldBe moduleName
+        client.functionLoad(replace = false, code) shouldBe libraryName
 
         client.functionFlush(SyncOption.SYNC)
         checkNotFound()

--- a/src/test/kotlin/io/github/crackthecodeabhi/kreds/commands/Utils.kt
+++ b/src/test/kotlin/io/github/crackthecodeabhi/kreds/commands/Utils.kt
@@ -68,8 +68,14 @@ internal class ClientSetup : BeforeSpec, Then<ClientSetup> {
         serverModules = client
             .info(ServerInfoSection.modules)!!
             .lines()
-            .filter { it.isNotEmpty() && !it.startsWith('#') }
-            .map { it.substring("module:name=".length, it.indexOf(',')) }
+            .mapNotNull { line ->
+                val start = "module:name="
+                if (!line.startsWith(start)) {
+                    null
+                } else {
+                    line.substring(start.length, line.indexOf(','))
+                }
+            }
             .toSet()
 
         andThen?.invoke(this)


### PR DESCRIPTION
Added support for these commands:
- [FCALL](https://redis.io/commands/fcall/)
- [FUNCTION DELETE](https://redis.io/commands/function-delete/)
- [FUNCTION FLUSH](https://redis.io/commands/function-flush/)
- [FUNCTION KILL](https://redis.io/commands/function-kill/)
- [FUNCTION LOAD](https://redis.io/commands/function-load/)

I wasn't able to add [FUNCTION LIST](https://redis.io/commands/function-list/) and [FUNCTION STATS](https://redis.io/commands/function-stats/) because they respond with RESP3 which isn't supported by Netty (https://github.com/netty/netty/issues/11449). Also [FUNCTION DUMP](https://redis.io/commands/function-dump/) and [FUNCTION RESTORE](https://redis.io/commands/function-restore/) because they use bulk strings to send raw bytes and I wasn't sure how to handle that.

Also, I updated Kotlin to the latest version because I was experiencing some weird issues with compilation and updating fixed it. Detekt didn't work with the new version so I updated it aswell.

EDIT: `INFO modules` returns now more things than just the installed modules so I also accounted for that